### PR TITLE
Remove osgi datasource auto init

### DIFF
--- a/h2-dist/pom.xml
+++ b/h2-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.orbisgis</groupId>
         <artifactId>h2gis</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2-dist</artifactId>

--- a/h2drivers/pom.xml
+++ b/h2drivers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2drivers</artifactId>

--- a/h2network/pom.xml
+++ b/h2network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2network</artifactId>

--- a/h2spatial-api/pom.xml
+++ b/h2spatial-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2spatial-api</artifactId>

--- a/h2spatial-ext-osgi/pom.xml
+++ b/h2spatial-ext-osgi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
   </parent>
     <artifactId>h2spatial-ext-osgi</artifactId>

--- a/h2spatial-ext/pom.xml
+++ b/h2spatial-ext/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2spatial-ext</artifactId>

--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/CreateSpatialExtension.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/CreateSpatialExtension.java
@@ -70,6 +70,8 @@ import org.h2gis.h2spatialext.function.spatial.trigonometry.ST_Azimuth;
 import org.h2gis.h2spatialext.function.system.DoubleRange;
 import org.h2gis.h2spatialext.function.system.IntegerRange;
 import org.h2gis.network.graph_creator.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -79,6 +81,7 @@ import org.h2gis.network.graph_creator.*;
  * @author Adam Gouge
  */
 public class CreateSpatialExtension {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateSpatialExtension.class);
 
     /**
      * @return instance of all built-ins functions
@@ -214,7 +217,7 @@ public class CreateSpatialExtension {
                 org.h2gis.h2spatial.CreateSpatialExtension.registerFunction(st, function, "");
             } catch (SQLException ex) {
                 // Catch to register other functions
-                ex.printStackTrace(System.err);
+                LOGGER.error(ex.getLocalizedMessage(), ex);
             }
         }
     }

--- a/h2spatial-osgi/pom.xml
+++ b/h2spatial-osgi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.orbisgis</groupId>
 		<artifactId>h2gis</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
+		<version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
 	</parent>
 	<artifactId>h2spatial-osgi</artifactId>

--- a/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
+++ b/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
@@ -66,12 +66,13 @@ public class DataSourceTracker implements ServiceTrackerCustomizer<DataSource,Fu
                         || "tcp".equalsIgnoreCase(properties.getProperty(DataSourceFactory.JDBC_NETWORK_PROTOCOL))) {
                     return null;
                 }
-                // Register built-ins functions
-                for(Function function : CreateSpatialExtension.getBuiltInsFunctions()) {
-                    CreateSpatialExtension.registerFunction(connection.createStatement(),function,"",false);
+                // Check if the database has been properly initialised by the DataSource service provider
+                if(JDBCUtilities.tableExists(connection, "PUBLIC.GEOMETRY_COLUMNS")) {
+                    // Register built-ins functions
+                    for (Function function : CreateSpatialExtension.getBuiltInsFunctions()) {
+                        CreateSpatialExtension.registerFunction(connection.createStatement(), function, "", false);
+                    }
                 }
-                CreateSpatialExtension.registerGeometryType(connection);
-                CreateSpatialExtension.registerSpatialTables(connection);
             } finally {
                 connection.close();
             }

--- a/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
+++ b/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
@@ -67,11 +67,8 @@ public class DataSourceTracker implements ServiceTrackerCustomizer<DataSource,Fu
                     return null;
                 }
                 // Check if the database has been properly initialised by the DataSource service provider
-                if(JDBCUtilities.tableExists(connection, "PUBLIC.GEOMETRY_COLUMNS")) {
-                    // Register built-ins functions
-                    for (Function function : CreateSpatialExtension.getBuiltInsFunctions()) {
-                        CreateSpatialExtension.registerFunction(connection.createStatement(), function, "", false);
-                    }
+                if(!JDBCUtilities.tableExists(connection, "PUBLIC.GEOMETRY_COLUMNS")) {
+                    return null;
                 }
             } finally {
                 connection.close();

--- a/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
+++ b/h2spatial-osgi/src/main/java/org/h2gis/h2spatial/osgi/DataSourceTracker.java
@@ -61,9 +61,8 @@ public class DataSourceTracker implements ServiceTrackerCustomizer<DataSource,Fu
             try {
                 DatabaseMetaData meta = connection.getMetaData();
                 // If not H2 or in client mode, does not register H2 spatial functions.
-                Properties properties = JDBCUrlParser.parse(meta.getURL());
                 if(!JDBCUtilities.H2_DRIVER_NAME.equals(meta.getDriverName())
-                        || "tcp".equalsIgnoreCase(properties.getProperty(DataSourceFactory.JDBC_NETWORK_PROTOCOL))) {
+                        || (meta.getURL() != null && meta.getURL().toLowerCase().startsWith("jdbc:h2:tcp://"))) {
                     return null;
                 }
                 // Check if the database has been properly initialised by the DataSource service provider

--- a/h2spatial/pom.xml
+++ b/h2spatial/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.orbisgis</groupId>
     <artifactId>h2gis</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>h2spatial</artifactId>

--- a/h2spatial/src/main/java/org/h2gis/h2spatial/CreateSpatialExtension.java
+++ b/h2spatial/src/main/java/org/h2gis/h2spatial/CreateSpatialExtension.java
@@ -71,6 +71,8 @@ import java.sql.Statement;
 import org.h2gis.h2spatial.internal.function.spatial.crs.ST_Transform;
 import org.h2gis.h2spatial.internal.function.spatial.predicates.ST_OrderingEquals;
 import org.h2gis.utilities.GeometryTypeCodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Add spatial features to an H2 database
@@ -87,6 +89,7 @@ import org.h2gis.utilities.GeometryTypeCodes;
 public class CreateSpatialExtension {
     /** H2 base type for geometry column {@link java.sql.ResultSetMetaData#getColumnTypeName(int)} */
     public static final String GEOMETRY_BASE_TYPE = "GEOMETRY";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateSpatialExtension.class);
 
     /**
      * @return instance of all built-ins functions
@@ -283,7 +286,12 @@ public class CreateSpatialExtension {
             ScalarFunction scalarFunction = (ScalarFunction)function;
             String functionName = scalarFunction.getJavaStaticMethod();
             if(dropAlias) {
-                st.execute("DROP ALIAS IF EXISTS " + functionAlias);
+                try {
+                    st.execute("DROP ALIAS IF EXISTS " + functionAlias);
+                } catch (SQLException ex) {
+                    // Ignore, some tables constraints may depend on this function
+                    LOGGER.debug(ex.getLocalizedMessage(), ex);
+                }
             }
             String deterministic = "";
             if(getBooleanProperty(function,ScalarFunction.PROP_DETERMINISTIC,false)) {

--- a/h2spatialtest/pom.xml
+++ b/h2spatialtest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>h2spatialtest</artifactId>

--- a/h2spatialtest/src/test/java/org/h2gis/osgi/test/BundleTest.java
+++ b/h2spatialtest/src/test/java/org/h2gis/osgi/test/BundleTest.java
@@ -29,6 +29,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.WKTReader;
+import org.h2gis.h2spatialext.CreateSpatialExtension;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,9 +136,15 @@ public class BundleTest {
         if(context.getServiceReference(DataSource.class.getName())==null) {
             // First UnitTest
             // Delete database
-            File dbFile = new File(DB_FILE_PATH+".h2.db");
+            File dbFile = new File(DB_FILE_PATH+".mv.db");
             if(dbFile.exists()) {
                 assertTrue(dbFile.delete());
+            }
+            Connection connection = dataSource.getConnection();
+            try {
+                CreateSpatialExtension.initSpatialExtension(connection);
+            } finally {
+                connection.close();
             }
             context.registerService(DataSource.class.getName(), dataSource, null);
         }

--- a/jts-osgi/pom.xml
+++ b/jts-osgi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.orbisgis</groupId>
         <artifactId>h2gis</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>jts</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.orbisgis</groupId>
     <artifactId>h2gis</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <name>H2GIS</name>
     <description>H2GIS is a spatial extension of the H2 database engine in the spirit of PostGIS.  It adds support for the Open Geospatial Consortium (OGC) Simple Features for SQL (SFSQL) functions.</description>
     <organization>

--- a/spatial-utilities/pom.xml
+++ b/spatial-utilities/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <name>spatial-utilities</name>

--- a/test-utilities/pom.xml
+++ b/test-utilities/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>h2gis</artifactId>
         <groupId>org.orbisgis</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The database should already be spatialized before the DataSource is registered in OSGi. Then DataSource tracker of h2spatial should be limited on registering/unregistering additional SQL functions.