### PR TITLE
Update H2 database version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- Dependency versions -->
         <maven-bundle-plugin-version>2.3.7</maven-bundle-plugin-version>
         <osgi-core-version>4.3.1</osgi-core-version>
-        <h2-version>1.4.184</h2-version>
+        <h2-version>1.4.186</h2-version>
         <h2-package>com.h2database</h2-package>
         <org.osgi.compendium-version>4.3.1</org.osgi.compendium-version>
         <jts-version>1.13</jts-version>


### PR DESCRIPTION
Update H2 dependency to the last published version  1.4.186 (2015-03-02), Beta