### PR TITLE
Use JTS if delaunay of points without quality arguments

### DIFF
--- a/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/mesh/ST_Delaunay.java
+++ b/h2spatial-ext/src/main/java/org/h2gis/h2spatialext/function/spatial/mesh/ST_Delaunay.java
@@ -100,8 +100,8 @@ public class ST_Delaunay extends DeterministicScalarFunction {
      * @throws org.jdelaunay.delaunay.error.DelaunayError
      */
     public static GeometryCollection createDT(Geometry geometry,  int flag,double qualityRefinement) throws SQLException, DelaunayError {
-        if(qualityRefinement >= 0) {
-            if (geometry != null) {
+        if (geometry != null) {
+            if(qualityRefinement >= 0) {
                 if (flag == 0) {
                     return DelaunayTools.toMultiPolygon(buildDelaunay(geometry, qualityRefinement).getTriangleList());
                 } else if (flag == 1) {
@@ -109,15 +109,15 @@ public class ST_Delaunay extends DeterministicScalarFunction {
                 } else {
                     throw new SQLException("Only flag 0 or 1 is supported.");
                 }
-            }
-        } else {
-            DelaunayTriangulationBuilder delaunayTriangulationBuilder = new DelaunayTriangulationBuilder();
-            delaunayTriangulationBuilder.setSites(geometry);
-            switch (flag) {
-                case 1:
-                    return (GeometryCollection)delaunayTriangulationBuilder.getEdges(geometry.getFactory());
-                default:
-                    return getTriangles(geometry.getFactory(), delaunayTriangulationBuilder);
+            } else {
+                DelaunayTriangulationBuilder delaunayTriangulationBuilder = new DelaunayTriangulationBuilder();
+                delaunayTriangulationBuilder.setSites(geometry);
+                switch (flag) {
+                    case 1:
+                        return (GeometryCollection)delaunayTriangulationBuilder.getEdges(geometry.getFactory());
+                    default:
+                        return getTriangles(geometry.getFactory(), delaunayTriangulationBuilder);
+                }
             }
         }
         return null;

--- a/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/function/spatial/mesh/MeshFunctionTest.java
+++ b/h2spatial-ext/src/test/java/org/h2gis/h2spatialext/function/spatial/mesh/MeshFunctionTest.java
@@ -70,7 +70,7 @@ public class MeshFunctionTest {
     public void test_ST_DelaunayWithPoints2() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_Delaunay('MULTIPOINT ((0 0 1), (10 0 1), (10 10 1), (5 5 1))'::GEOMETRY);");
         rs.next();
-        assertGeometryEquals("MULTIPOLYGON(((0 0 1, 10 0 1, 5 5 1, 0 0 1)),  ((10 0 1, 5 5 1, 10 10 1, 10 0 1)))",  rs.getBytes(1));
+        assertGeometryEquals("MULTIPOLYGON (((0 0 1, 10 0 1, 5 5 1, 0 0 1)), ((5 5 1, 10 0 1, 10 10 1, 5 5 1)))",  rs.getBytes(1));
         rs.close();
     }
 
@@ -79,7 +79,7 @@ public class MeshFunctionTest {
         ResultSet rs = st.executeQuery("SELECT ST_Delaunay('GEOMETRYCOLLECTION (POLYGON ((150 380 1, 110 230 1, 180 190 1, 230 300 1, 320 280 1, 320 380 1, 150 380 1)),"
                 + "  LINESTRING (70 330 1, 280 220 1))'::GEOMETRY);");
         rs.next();
-        assertGeometryEquals("MULTIPOLYGON (((70 330 1, 110 230 1, 150 380 1, 70 330 1)), ((110 230 1, 230 300 1, 180 190 1, 110 230 1)), ((110 230 1, 230 300 1, 150 380 1, 110 230 1)), ((180 190 1, 230 300 1, 280 220 1, 180 190 1)), ((280 220 1, 230 300 1, 320 280 1, 280 220 1)), ((230 300 1, 320 380 1, 320 280 1, 230 300 1)), ((230 300 1, 320 380 1, 150 380 1, 230 300 1))) ", rs.getBytes(1));
+        assertGeometryEquals("MULTIPOLYGON (((70 330 1, 110 230 1, 150 380 1, 70 330 1)), ((150 380 1, 110 230 1, 230 300 1, 150 380 1)), ((150 380 1, 230 300 1, 320 380 1, 150 380 1)), ((320 380 1, 230 300 1, 320 280 1, 320 380 1)), ((180 190 1, 280 220 1, 230 300 1, 180 190 1)), ((180 190 1, 230 300 1, 110 230 1, 180 190 1)), ((230 300 1, 280 220 1, 320 280 1, 230 300 1)))", rs.getBytes(1));
         rs.close();
     }
 
@@ -87,7 +87,7 @@ public class MeshFunctionTest {
     public void test_ST_DelaunayWithLines() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_Delaunay('MULTILINESTRING ((1.1 8 1, 8 8 1), (2 3.1 1, 8 5.1 1))'::GEOMETRY);");
         rs.next();
-        assertGeometryEquals("MULTIPOLYGON (((1.1 8 1, 2 3.1 1, 8 5.1 1, 1.1 8 1)), ((8 5.1 1, 1.1 8 1, 8 8 1, 8 5.1 1)))", rs.getBytes(1));
+        assertGeometryEquals("MULTIPOLYGON (((1.1 8 1, 2 3.1 1, 8 5.1 1, 1.1 8 1)), ((1.1 8 1, 8 5.1 1, 8 8 1, 1.1 8 1)))", rs.getBytes(1));
         rs.close();
     }
 
@@ -95,7 +95,7 @@ public class MeshFunctionTest {
     public void test_ST_DelaunayAsMultiPolygon() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_Delaunay('POLYGON ((1.1 9 1, 1.1 3 1, 5.1 1.1 1, 9.5 6.4 1, 8.8 9.9 1, 5 8 1, 1.1 9 1))'::GEOMETRY, 0);");
         rs.next();
-        assertGeometryEquals("MULTIPOLYGON(((1.1 3 1, 5 8 1, 1.1 9 1, 1.1 3 1)),   ((1.1 3 1, 5 8 1, 5.1 1.1 1, 1.1 3 1)),  ((5 8 1, 9.5 6.4 1, 5.1 1.1 1, 5 8 1)),  ((5 8 1, 1.1 9 1, 8.8 9.9 1, 5 8 1)),  ((5 8 1, 9.5 6.4 1, 8.8 9.9 1, 5 8 1)))",  rs.getBytes(1));
+        assertGeometryEquals("MULTIPOLYGON (((1.1 9 1, 1.1 3 1, 5 8 1, 1.1 9 1)), ((1.1 9 1, 5 8 1, 8.8 9.9 1, 1.1 9 1)), ((8.8 9.9 1, 5 8 1, 9.5 6.4 1, 8.8 9.9 1)), ((5.1 1.1 1, 9.5 6.4 1, 5 8 1, 5.1 1.1 1)), ((5.1 1.1 1, 5 8 1, 1.1 3 1, 5.1 1.1 1)))",  rs.getBytes(1));
         rs.close();
     }
 
@@ -103,7 +103,7 @@ public class MeshFunctionTest {
     public void test_ST_DelaunayAsMultiLineString() throws Exception {
         ResultSet rs = st.executeQuery("SELECT ST_Delaunay('POLYGON ((1.1 9 1, 1.1 3 1, 5.1 1.1 1, 9.5 6.4 1, 8.8 9.9 1, 5 8 1, 1.1 9 1))'::GEOMETRY, 1);");
         rs.next();
-        assertGeometryEquals("MULTILINESTRING((1.1 3 1, 1.1 9 1), (1.1 3 1, 5 8 1),  (1.1 9 1, 5 8 1), (1.1 3 1, 5.1 1.1 1),  (5 8 1, 5.1 1.1 1), (5 8 1, 9.5 6.4 1),  (5 8 1, 8.8 9.9 1), (1.1 9 1, 8.8 9.9 1),(5.1 1.1 1, 9.5 6.4 1),  (8.8 9.9 1, 9.5 6.4 1))",rs.getBytes(1));
+        assertGeometryEquals("MULTILINESTRING ((1.1 9 1, 8.8 9.9 1), (1.1 3 1, 1.1 9 1), (1.1 3 1, 5.1 1.1 1), (5.1 1.1 1, 9.5 6.4 1), (8.8 9.9 1, 9.5 6.4 1), (5 8 1, 9.5 6.4 1), (5 8 1, 8.8 9.9 1), (1.1 9 1, 5 8 1), (1.1 3 1, 5 8 1), (5 8 1, 5.1 1.1 1))",rs.getBytes(1));
         rs.close();
     }
 


### PR DESCRIPTION
Use JTS instead of JDelaunay if quality constraint is not set. Currently, JTS Delaunay triangulation is more robust than JDelaunay for a set of points.

Todo in JDelaunay fix invalid mesh (triangle incircle that contains another triangle vertex)